### PR TITLE
feat(faq): sharpen Stacks answer + add Launchpad replacement question

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -484,7 +484,11 @@ const FAQ_ITEMS: { q: string; a: string }[] = [
   },
   {
     q: "What's the difference between DockPops and macOS Dock folders (Stacks)?",
-    a: "macOS Stacks show a single folder's contents in a fan or grid. DockPops gives you named, curated groups of apps, files, AND folders — multiple of them, swipeable from a single Dock icon, with Quick Look previews and keyboard navigation. Think iPhone home-screen folders, in your Mac Dock.",
+    a: "Stacks just show what's inside a real folder on disk — useful for Downloads, awkward for grouping apps by intent. You can't easily build \"my Office apps\" or \"my Creative apps\" without making throwaway folders of aliases. DockPops lets you curate Pops by use case: drag any mix of apps, files, and folders into a Pop, name it, and access it from your Dock. Multiple Pops, swipeable, with Quick Look and keyboard navigation built in.",
+  },
+  {
+    q: "Is DockPops a replacement for Launchpad?",
+    a: "Yes — and macOS 26 (Tahoe) removed Launchpad, leaving a lot of users without it. DockPops is the natural successor: same one-click access from your Dock, but with curated Pops you build yourself instead of an automatic grid of every app on your system. Add just the apps you actually use, plus files and folders, and swipe between Pops. Works on macOS 14, 15, and 26.",
   },
   {
     q: "How is DockPops different from Alfred, Raycast, or Spotlight?",


### PR DESCRIPTION
Two FAQ revisions based on direct feedback.

## 1. Stacks answer (Q2) rewritten

Old version leaned on visual layout ('fan or grid'). The real differentiator is **what** Stacks are: they show one folder's contents on disk. You can't easily build curated groups like 'my Office apps' or 'my Creative apps' without making throwaway alias folders.

**Before:**
> macOS Stacks show a single folder's contents in a fan or grid. DockPops gives you named, curated groups of apps, files, AND folders — multiple of them, swipeable from a single Dock icon...

**After:**
> Stacks just show what's inside a real folder on disk — useful for Downloads, awkward for grouping apps by intent. You can't easily build 'my Office apps' or 'my Creative apps' without making throwaway folders of aliases. DockPops lets you curate Pops by use case: drag any mix of apps, files, and folders into a Pop, name it, and access it from your Dock...

## 2. New Q3: Is DockPops a replacement for Launchpad?

**macOS 26 (Tahoe) removed Launchpad** — leaving a significant cohort of Mac users stranded without their muscle-memory app grid. 'Launchpad replacement,' 'Launchpad removed Tahoe,' and 'macOS 26 Launchpad' are now high-volume search terms.

DockPops legitimately fills the gap:
- Same one-click Dock access (icon → grid of apps)
- Curated Pops instead of an automatic grid of every installed app
- Works on macOS 14, 15, AND 26 (covering both pre- and post-removal users)

The answer addresses the removal directly and positions DockPops as 'the natural successor.'

## SEO impact

This adds searchable surface for:
- 'Launchpad replacement' / 'Launchpad alternative'
- 'macOS Tahoe Launchpad removed' / 'macOS 26 no Launchpad'
- 'app grid for Mac' / 'app launcher for Mac Dock'
- (refined) 'Mac app folder' / 'group apps in Dock' / 'macOS Stacks alternative'

FAQ count now 9. Schema.org FAQPage JSON-LD auto-includes the new question.

## Verification

- `npm run build` clean
- No new dependencies, no new bundle weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)