### PR TITLE
fix(pricing): disambiguate Premium 'Custom Dock icon per Pop' bullet

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -184,7 +184,7 @@ export default function DockPopsPage() {
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="text-orange-400 mt-0.5">&#10003;</span>
-                  Custom Dock icon per Pop
+                  Customize each Pop&apos;s Dock icon (color, grid density, variant)
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="text-orange-400 mt-0.5">&#10003;</span>


### PR DESCRIPTION
## Why

After PR #21 made the Multiple Dock Icons feature catalog correctly mark Companion/linking as FREE, the Premium pricing card's old *'Custom Dock icon per Pop'* line became ambiguous — it could be misread two ways:

- ❌ 'A custom Dock icon for each Pop' → would imply Multiple Dock Icons is premium (wrong; it's free)
- ✅ 'Customize each Pop's Dock icon appearance' → what we actually mean

## Source-of-truth audit

| Feature | Tier | File |
|---|---|---|
| Having multiple Dock icons (one per Pop) via Companion or Shortcuts | **FREE** | `MultipleDockIconsPane.swift` — 0 `isUnlocked` checks |
| Customizing per-Pop Dock icon appearance — source, color, grid density | **PREMIUM** | `DockIconPane.swift` — 3 `isUnlocked` gates |

The Premium card bullet now matches the actual gated functionality.

## Change

| Before | After |
|---|---|
| Custom Dock icon per Pop | Customize each Pop's Dock icon (color, grid density, variant) |

## Verification

- `npm run build` clean
- Confirmed via grep: `MultipleDockIconsPane.swift` has 0 `isUnlocked`; `DockIconPane.swift` has the 3 gates the new wording references

🤖 Generated with [Claude Code](https://claude.com/claude-code)