### PR TITLE
Add direct .dmg download button (nav, hero, pricing)

### DIFF
--- a/app/DirectDownloadButton.tsx
+++ b/app/DirectDownloadButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/* Always-latest stable asset on the public releases repo. GitHub keeps
+   /releases/latest/download/<asset> pointing at the newest release, and every
+   release ships a version-less `DockPops.dmg` alongside the versioned one — so
+   this URL never needs touching when a new build ships. The release asset is
+   served with Content-Disposition: attachment, so the click downloads directly.
+   Notarized .dmg, auto-updates via Sparkle. */
+const DMG_URL =
+  "https://github.com/Pixley-Growth/dockpops-releases/releases/latest/download/DockPops.dmg";
+
+/* Direct-download counterpart to <DownloadBadge>. Styled to sit as an
+   equal-weight pair beside the Mac App Store badge (matched height + radius). */
+export default function DirectDownloadButton({
+  location,
+  size = "lg",
+}: {
+  location: string;
+  size?: "lg" | "sm";
+}) {
+  const lg = size === "lg";
+  return (
+    <a
+      href={DMG_URL}
+      aria-label="Download the DockPops .dmg directly"
+      onClick={() => {
+        window.gtag?.("event", "download_click", { location, method: "direct_dmg" });
+      }}
+      className={`inline-flex items-center rounded-[10px] bg-white text-black border border-black/10 shadow-sm hover:opacity-90 transition-opacity ${
+        lg ? "h-12 gap-2.5 px-4" : "h-7 gap-1.5 px-2.5"
+      }`}
+    >
+      {/* download-into-tray glyph */}
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden
+        className={lg ? "w-5 h-5" : "w-3.5 h-3.5"}
+      >
+        <path
+          d="M12 3v10m0 0l-4-4m4 4l4-4M5 17v2a2 2 0 002 2h10a2 2 0 002-2v-2"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span className="flex flex-col text-left leading-none">
+        <span className={lg ? "text-[10px]" : "text-[8px]"}>Download directly</span>
+        <span className={`font-semibold ${lg ? "text-[17px] mt-0.5" : "text-[11px]"}`}>
+          macOS .dmg
+        </span>
+      </span>
+    </a>
+  );
+}

--- a/app/HeroDemo.tsx
+++ b/app/HeroDemo.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import Image from "next/image";
+import DirectDownloadButton from "./DirectDownloadButton";
 
 /* Apple squircle clip-path (objectBoundingBox) — continuous curvature corners */
 const SQUIRCLE =
@@ -463,9 +464,12 @@ export default function HeroDemo({ easterEgg = false }: { easterEgg?: boolean } 
           >
             Organize your Dock like your iPhone
           </p>
-<a href="https://apps.apple.com/us/app/dockpops/id6759999009?mt=12&ct=website_hero" className="hover:opacity-90 transition-opacity" onClick={() => { window.gtag?.('event', 'download_click', { location: 'hero' }); }}>
-            <Image src="/mac-app-store-badge.svg" alt="Download on the Mac App Store" width={200} height={60} className="h-12 w-auto" />
-          </a>
+<div className="flex flex-wrap items-center justify-center gap-3">
+            <a href="https://apps.apple.com/us/app/dockpops/id6759999009?mt=12&ct=website_hero" className="hover:opacity-90 transition-opacity" onClick={() => { window.gtag?.('event', 'download_click', { location: 'hero' }); }}>
+              <Image src="/mac-app-store-badge.svg" alt="Download on the Mac App Store" width={200} height={60} className="h-12 w-auto" />
+            </a>
+            <DirectDownloadButton location="hero" size="lg" />
+          </div>
         </div>
 
         {/* Windows */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import HeroDemo from "./HeroDemo";
 import FeatureStory from "./FeatureStory";
 import DownloadBadge from "./DownloadBadge";
+import DirectDownloadButton from "./DirectDownloadButton";
 
 export const metadata: Metadata = {
   openGraph: {
@@ -32,7 +33,10 @@ export default function DockPopsPage() {
             <a href="#faq" className="text-white/50 hover:text-white/80 transition-colors">FAQ</a>
             <a href="#support" className="text-white/50 hover:text-white/80 transition-colors">Support</a>
           </div>
-          <DownloadBadge location="nav" className="h-7 w-auto" height={36} width={120} />
+          <div className="flex items-center gap-2">
+            <DownloadBadge location="nav" className="h-7 w-auto" height={36} width={120} />
+            <DirectDownloadButton location="nav" size="sm" />
+          </div>
         </div>
       </nav>
 
@@ -163,8 +167,11 @@ export default function DockPopsPage() {
             </div>
           </div>
 
-          {/* Shared CTA below pricing cards */}
-          <DownloadBadge location="pricing" className="h-12 w-auto mx-auto mb-12" height={48} width={160} />
+          {/* Shared CTA below pricing cards — App Store + direct .dmg, equal weight */}
+          <div className="flex flex-wrap items-center justify-center gap-3 mb-12">
+            <DownloadBadge location="pricing" className="h-12 w-auto" height={48} width={160} />
+            <DirectDownloadButton location="pricing" size="lg" />
+          </div>
 
 
 


### PR DESCRIPTION
Adds a direct-download CTA beside the Mac App Store badge in all three download spots (nav, hero, pricing), equal weight.

- New `DirectDownloadButton.tsx` — white pill (inverse of the black App Store badge), matched height/radius, download glyph + "Download directly / macOS .dmg".
- Links to `https://github.com/Pixley-Growth/dockpops-releases/releases/latest/download/DockPops.dmg` — always-latest stable asset (no per-release edits; releases ship a version-less `DockPops.dmg`). Asset serves `Content-Disposition: attachment`, so it downloads on click.
- Reuses the `download_click` gtag event with `method: "direct_dmg"`.

## Verification
- `npm run build` clean (8/8 static pages), `tsc --noEmit` clean
- Renders in all 3 spots on localhost; verified the latest-download URL resolves to the signed asset (200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)