### PR TITLE
Direct Download label + correct Companion FAQ

### DIFF
--- a/app/DirectDownloadButton.tsx
+++ b/app/DirectDownloadButton.tsx
@@ -28,7 +28,7 @@ export default function DirectDownloadButton({
   return (
     <a
       href={DMG_URL}
-      aria-label="Download the DockPops .dmg directly"
+      aria-label="Direct Download for macOS"
       onClick={() => {
         window.gtag?.("event", "download_click", { location, method: "direct_dmg" });
       }}
@@ -51,11 +51,8 @@ export default function DirectDownloadButton({
           strokeLinejoin="round"
         />
       </svg>
-      <span className="flex flex-col text-left leading-none">
-        <span className={lg ? "text-[10px]" : "text-[8px]"}>Download directly</span>
-        <span className={`font-semibold ${lg ? "text-[17px] mt-0.5" : "text-[11px]"}`}>
-          macOS .dmg
-        </span>
+      <span className={`font-semibold ${lg ? "text-[15px]" : "text-[12px]"}`}>
+        Direct Download
       </span>
     </a>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -239,8 +239,8 @@ export default function DockPopsPage() {
 
 const FAQ_ITEMS: { q: string; a: string }[] = [
   {
-    q: "Why do I need a Companion app for DockPops?",
-    a: "macOS doesn't allow a single sandboxed app to add more than one Dock icon — it's an App Store security rule, not a DockPops limitation. DockPops Companion is a free sibling app whose only job is to be those extra Dock icons. Install one per Pop, and each Companion becomes a real Dock tile that opens its Pop instantly. The main DockPops app runs everything; Companion just fills the gap macOS can't.",
+    q: "Do I need the Companion app for multiple Dock icons?",
+    a: "Only with the Mac App Store version. App Store apps are sandboxed, and macOS won't let a single sandboxed app add more than one Dock icon — so DockPops Companion, a free sibling app, provides each extra Dock tile (install one per Pop). The direct download isn't sandboxed, so it creates the extra Dock icons itself — no Companion app needed. Either way, the main DockPops app runs everything.",
   },
   {
     q: "What's the difference between DockPops and macOS Dock folders (Stacks)?",


### PR DESCRIPTION
Two copy fixes on top of the direct-download button:

- **Button label** — drop the techy ".dmg"; the button now reads simply **Direct Download** (nav, hero, pricing).
- **Companion FAQ** — was wrong: it implied you always need the Companion app. The Companion is a workaround for the **sandboxed App Store build** only. The direct download is non-sandboxed (`DockPopsComplete.entitlements` has app-sandbox off) and writes the extra Dock icons (Poplets) itself — no Companion needed. Retitled the question to "Do I need the Companion app for multiple Dock icons?"

Verified: `npm run build` + `tsc` clean; button renders in all 3 spots, FAQ updated, old wording gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)